### PR TITLE
Add text formatting for `!whitelist`

### DIFF
--- a/UhcBot.py
+++ b/UhcBot.py
@@ -97,7 +97,7 @@ async def on_message(message):
             await client.send_message(message.channel, "Status changed! Let's get roling!")
         elif command == "whitelist":
             if _modRole in message.author.roles or _adminRole in message.author.roles:
-                await client.send_message(message.channel, "Here is the whitelist: {list}".format(list=whitelistjson))
+                await client.send_message(message.channel, "Here is the whitelist: ```{}```".format(whitelistjson))
             else:
                 await client.send_message(message.channel, "You don't have the permissions needed to use this command! If this is a mistake please contact a Moderator or Administrator")
 


### PR DESCRIPTION
This makes it easier to copy/paste the whitelist and makes it look nicer. (Also `.format` doesn't *need* to be keyword, it only really needs to be keyword when there are multiple things being changed in the string)

(It also wouldn't let me do the stuff on the UHCBOT/UHCBOT Github repository, I had to Fork it)